### PR TITLE
Fix: Correct Python RunCommand configuration

### DIFF
--- a/src/code-sandbox-mcp/languages/types.go
+++ b/src/code-sandbox-mcp/languages/types.go
@@ -30,7 +30,7 @@ var SupportedLanguages = map[Language]LanguageConfig{
 		Image:           "ghcr.io/astral-sh/uv:debian-slim",
 		DependencyFiles: []string{"requirements.txt", "pyproject.toml", "setup.py"},
 		InstallCommand:  []string{"pip", "install", "-r", "requirements.txt"},
-		RunCommand:      []string{"uvx", "run", "main.py"},
+		RunCommand:      []string{"uv", "run", "main.py"},
 		FileExtension:   "py",
 	},
 	Go: {


### PR DESCRIPTION
This PR fixes the issue https://github.com/Automata-Labs-team/code-sandbox-mcp/issues/2 where the incorrect command uvx run main.py was used for running Python scripts.
Since uvx is intended for executing globally installed binaries, the correct approach is to use uv run main.py,
which ensures the script runs within the appropriate virtual environment managed by uv.

Changes:
• Replace uvx run main.py with uv run main.py in the Python RunCommand configuration.

Why?
• Prevents execution issues caused by an incorrect command.
• Ensures compatibility with uv’s virtual environment handling.