### PR TITLE
Add Container Cleanup Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ Executes code snippets in an isolated Docker container.
 - `language` (enum, required): Programming language to use
   - Supported values: `python`, `go`, `nodejs`
   - Note: If your Python code requires external dependencies, it is recommended to use the `run_project` tool instead. Go and Node.js script dependencies are automatically installed.
+- `cleanup` (string, required): Automatically removes the container after execution when set to `true`.
+  - Supported values: `false` (default), `true`
 
 **Returns:**
 - Container execution output (stdout + stderr)
+- Created container ID
 
 **Features:**
 - Automatic dependency detection and installation
@@ -96,6 +99,24 @@ Executes a project directory in a containerized environment.
 
 **Returns:**
 - The resource URI of the container logs.
+
+#### `cleanup_container`
+Manages removal of Docker containers after execution. Automatically called by `run_code` when cleanup is enabled.
+
+**Parameters:**
+- `containerId` (string, required): Container ID from run_code/run_project response
+- `force` (string, optional): Set to 'true' to force removal of running containers
+
+**Example:**
+```json
+{
+  "tool": "cleanup_container",
+  "arguments": {
+    "containerId": "abc123",
+    "force": "true"
+  }
+}
+```
 
 **Features:**
 - Automatic dependency detection and installation
@@ -203,7 +224,9 @@ Node.js 23+ includes built-in TypeScript support:
 - Isolated execution environment using Docker containers
 - Resource limitations through Docker container constraints
 - Separate stdout and stderr streams
-- Clean container cleanup after execution
+- Automatic container cleanup after execution (enabled by default in `run_code`)
+- Manual cleanup option via `cleanup_container` tool
+- Force removal capability for stuck containers
 - Project files mounted read-only in containers
 
 ## 🛠️ Development

--- a/src/code-sandbox-mcp/main.go
+++ b/src/code-sandbox-mcp/main.go
@@ -64,6 +64,7 @@ func main() {
 	runCodeTool := mcp.NewTool("run_code",
 		mcp.WithDescription(
 			"Run code in a sandboxed docker container with automatic dependency detection and installation. \n"+
+				"The tool can also cleanup the container after execution. \n"+
 				"The tool will analyze your code and install required packages automatically. \n"+
 				"The supported languages are: "+GenerateEnumTag()+". \n"+
 				"Returns the execution logs of the container.",
@@ -76,6 +77,11 @@ func main() {
 			mcp.Required(),
 			mcp.Description("The programming language to use"),
 			mcp.Enum(deps.AllLanguages.ToArray()...),
+		),
+		mcp.WithString("cleanup",
+			mcp.Required(),
+			mcp.Description("Set to 'true' to enable container cleanup after run_code execution"),
+			mcp.Enum("true", "false"),
 		),
 	)
 

--- a/src/code-sandbox-mcp/main.go
+++ b/src/code-sandbox-mcp/main.go
@@ -108,6 +108,24 @@ func main() {
 		),
 	)
 
+	// Add new cleanup_container tool
+	cleanupContainerTool := mcp.NewTool("cleanup_container",
+		mcp.WithDescription(
+			"Clean up a running Docker container created by run_code or run_project tools.\n"+
+				"This tool removes the specified container and releases associated resources.\n"+
+				"Returns a confirmation message upon successful cleanup.",
+		),
+		mcp.WithString("containerId",
+			mcp.Required(),
+			mcp.Description("The ID of the container to clean up"),
+		),
+		mcp.WithString("force",
+			mcp.Required(),
+			mcp.Description("Set to 'true' to forcefully remove the container even if it's running"),
+			mcp.Enum("true", "false"),
+		),
+	)
+
 	// Register dynamic resource for container logs
 	// Dynamic resource example - Container Logs by ID
 	containerLogsTemplate := mcp.NewResourceTemplate(
@@ -121,6 +139,7 @@ func main() {
 	s.AddResourceTemplate(containerLogsTemplate, resources.GetContainerLogs)
 	s.AddTool(runCodeTool, tools.RunCodeSandbox)
 	s.AddTool(runProjectTool, tools.RunProjectSandbox)
+	s.AddTool(cleanupContainerTool, tools.CleanupContainerTool)
 
 	switch *transport {
 	case "stdio":

--- a/src/code-sandbox-mcp/tools/cleanup.go
+++ b/src/code-sandbox-mcp/tools/cleanup.go
@@ -1,0 +1,55 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+	"log"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/moby/moby/client"
+)
+
+var CleanupEnabled bool
+
+// CleanupContainer removes a container after it has finished executing
+func CleanupContainer(ctx context.Context, containerID string, waitForExit bool, force bool, timeoutSeconds int) error {
+
+    // Create Docker client
+    cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+    if err != nil {
+        return fmt.Errorf("Failed to create Docker client for cleanup: %w", err)
+    }
+    defer cli.Close()
+
+    if waitForExit {
+        // Wait for container to exit with timeout
+        statusCh, errCh := cli.ContainerWait(ctx, containerID, container.WaitConditionNotRunning)
+        
+        select {
+        case err := <-errCh:
+            if err != nil {
+                fmt.Errorf("Error waiting for container %s: %v\n", containerID, err)
+                // Continue with removal even if there's an error waiting
+            }
+        case <-statusCh:
+            // Container exited normally
+            log.Printf("Container %s exited, proceeding with cleanup\n", containerID)
+        case <-time.After(time.Duration(timeoutSeconds) * time.Second):
+            log.Printf("Timeout waiting for container %s to exit\n", containerID)
+            // Continue with removal
+        }
+    }
+
+    // Remove the container
+    removeOptions := container.RemoveOptions{
+        Force: force,
+    }
+    
+    if err := cli.ContainerRemove(ctx, containerID, removeOptions); err != nil {
+        return fmt.Errorf("Failed to remove container %s: %w", containerID, err)
+    }
+    
+    log.Printf("Successfully removed container %s\n", containerID)
+    return nil
+}

--- a/src/code-sandbox-mcp/tools/run_code_test.go
+++ b/src/code-sandbox-mcp/tools/run_code_test.go
@@ -74,7 +74,7 @@ func TestRunInDocker(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := languages.SupportedLanguages[tt.language]
-			output, err := runInDocker(ctx, config.RunCommand, config.Image, tt.code, tt.language)
+			output, _, err := runInDocker(ctx, config.RunCommand, config.Image, tt.code, tt.language)
 
 			// Check error cases
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
# Add Container Cleanup Feature

## Overview
This PR introduces automated container lifecycle management through:

1. New `cleanup_container` tool
2. Automatic post-execution cleanup
3. Force removal capability

## Changes

### Core Features
- Added `cleanup_container` tool for manual container removal
- Integrated automatic cleanup in `run_code` via `cleanup` flag
 correspondente- Implemented force removal for stuck containers
- Added progress tracking during container operations

### Code Changes
```plaintext
src/code-sandbox-mcp/tools/cleanup.go (new)
src/code-sandbox-mcp/main.go
src/code-sandbox-mcp/tools/run_code.go
README.md
```

## Documentation
Updated documentation:
```plaintext
README.md                 - Cleanup tool parameters, security section
```

### New Tool Parameters
```markdown
#### `cleanup_container`
Manages Docker container lifecycle
- `containerId`: Target container ID
- `force`: Force removal (true/false)
```

### New Return Value
The `run_code` tool now provides created container ID 
```markdown
#### `run_code`
Executes code snippets in an isolated Docker container.

**Parameters:**
...

**Returns:**
- Container execution output (stdout + stderr)
- Created container ID
```
