### PR TITLE
fix: Fix OpenAPI schema validation in code-sandbox-mcp

### DIFF
--- a/src/code-sandbox-mcp/main.go
+++ b/src/code-sandbox-mcp/main.go
@@ -120,6 +120,7 @@ func main() {
 			mcp.Required(),
 			mcp.Description("List of command(s) to run in the sandboxed environment"),
 			mcp.Description("Example: [\"apt-get update\", \"pip install numpy\", \"python script.py\"]"),
+			mcp.Items(map[string]any{"type": "string"}),
 		),
 	)
 


### PR DESCRIPTION
OpenAPI schema validation was failing due to a missing required field in the OpenAPI spec. This commit adds the missing field to ensure that the OpenAPI schema validation passes successfully.