### PR TITLE
Fix: Correct schema for sandbox_exec commands parameter

### DIFF
--- a/src/code-sandbox-mcp/main.go
+++ b/src/code-sandbox-mcp/main.go
@@ -120,7 +120,7 @@ func main() {
 			mcp.Required(),
 			mcp.Description("List of command(s) to run in the sandboxed environment"),
 			mcp.Description("Example: [\"apt-get update\", \"pip install numpy\", \"python script.py\"]"),
-			mcp.Items(map[string]any{"type": "string"}), // This line was added
+			mcp.Items(map[string]any{"type": "string"}),
 		),
 	)
 

--- a/src/code-sandbox-mcp/main.go
+++ b/src/code-sandbox-mcp/main.go
@@ -120,6 +120,7 @@ func main() {
 			mcp.Required(),
 			mcp.Description("List of command(s) to run in the sandboxed environment"),
 			mcp.Description("Example: [\"apt-get update\", \"pip install numpy\", \"python script.py\"]"),
+			mcp.Items(map[string]any{"type": "string"}), // This line was added
 		),
 	)
 


### PR DESCRIPTION
This pull request corrects the OpenAPI schema for the `commands` parameter of the `sandbox_exec` tool.

The `commands` parameter is defined as an array, but it was missing the `items: { "type": "string" }` specification. This change adds the missing item type definition, ensuring the schema accurately reflects that the `commands` array should contain strings.

This improves the schema's accuracy and helps with tooling and validation.